### PR TITLE
Add dependency conveniences

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: mix
+    directory: "/"
+    schedule:
+      interval: daily
+    pull-request-branch-name:
+      separator: "-"
+    open-pull-requests-limit: 99
+    allow:
+      - dependency-type: production

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ $ mix format
 $ mix credo--strict
  ```
 
-Our current `mix.exs` setup in this demo assumes that you will have Uncharted cloned into the same directory where you have this demo cloned. If necessary, you can change the paths to your local versions of Uncharted and Uncharted Phoenix by updating the `@uncharted_path` instance variable and the `path` attribute for each dependency in the function block of `uncharted_deps/1` in `mix.exs` that is specifically for local environments. Just be sure not to commit any of these changes.
+Our current `mix.exs` setup in this demo assumes that you will have Uncharted cloned into the same directory where you have this demo cloned. If necessary, you can change the paths to your local versions of Uncharted and Uncharted Phoenix by updating the `@uncharted_path` instance variable. Just be sure not to commit this change.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ $ mix test
 $ mix format
 $ mix credo--strict
  ```
+
+Our current `mix.exs` setup in this demo assumes that you will have Uncharted cloned into the same directory where you have this demo cloned. If necessary, you can change the paths to your local versions of Uncharted and Uncharted Phoenix by updating the `@uncharted_path` instance variable and the `path` attribute for each dependency in the function block of `uncharted_deps/1` in `mix.exs` that is specifically for local environments. Just be sure not to commit any of these changes.

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule Demo.MixProject do
   use Mix.Project
 
+  @uncharted_path "../uncharted"
+
   def project do
     [
       app: :demo,
@@ -46,21 +48,36 @@ defmodule Demo.MixProject do
   # Specifies your project dependencies.
   #
   # Type `mix help deps` for examples and options.
-  defp deps do
+  # This refers to dependencies shared among :prod, :test_local, :test, and :dev environments.
+  defp deps() do
     [
-      {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:excoveralls, "~> 0.11", only: :test},
+      {:credo, "~> 1.4", only: [:dev, :test, :test_local], runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev, :test, :test_local], runtime: false},
+      {:excoveralls, "~> 0.11", only: [:test, :test_local]},
       {:phoenix, "~> 1.5.4"},
       {:phoenix_live_view, "~> 0.15"},
-      {:floki, ">= 0.0.0", only: :test},
+      {:floki, ">= 0.0.0", only: [:test, :test_local]},
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:telemetry_metrics, "~> 0.4"},
       {:telemetry_poller, "~> 0.4"},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"},
+      {:plug_cowboy, "~> 2.0"}
+    ] ++ uncharted_deps(local: File.exists?(@uncharted_path))
+  end
+
+  # This refers to dependencies only needed for local development purposes.
+  defp uncharted_deps(local: true) do
+    [
+      {:uncharted, only: [:dev, :test], path: "../uncharted/uncharted"},
+      {:uncharted_phoenix, only: [:dev, :test], path: "../uncharted/uncharted_phoenix"}
+    ]
+  end
+
+  # This refers to dependencies only needed for prod.
+  defp uncharted_deps(local: false) do
+    [
       {:uncharted,
        github: "unchartedelixir/uncharted", branch: "master", sparse: "uncharted", override: true},
       {:uncharted_phoenix,

--- a/mix.exs
+++ b/mix.exs
@@ -70,8 +70,8 @@ defmodule Demo.MixProject do
   # This refers to dependencies only needed for local development purposes.
   defp uncharted_deps(local: true) do
     [
-      {:uncharted, only: [:dev, :test], path: "../uncharted/uncharted"},
-      {:uncharted_phoenix, only: [:dev, :test], path: "../uncharted/uncharted_phoenix"}
+      {:uncharted, only: [:dev, :test], path: "#{@uncharted_path}/uncharted"},
+      {:uncharted_phoenix, only: [:dev, :test], path: "#{@uncharted_path}/uncharted_phoenix"}
     ]
   end
 


### PR DESCRIPTION
I'm hoping this will make it easier for people to start contributing because they won't run into the issue of not knowing how to point the demo to their local versions of Uncharted and Uncharted Phoenix.

I also _tried_ to set up dependabot in the hopes that it will make keeping the versions of Uncharted and Uncharted Phoenix up to date easier, but I'm not 100% sure it will work.